### PR TITLE
Gemfileから不要なgemを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ group :development do
 
   gem 'guard-rspec'
 
-  # ref. https://github.com/guard/guard#efficient-filesystem-handling
-  gem 'rb-inotify', :require => false
-  gem 'rb-fsevent', :require => false
-  gem 'rb-fchange', :require => false
-
   # Runs on Mac OS X
   gem 'growl'
   # Runs on Linux, FreeBSD, OpenBSD and Solaris

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,11 +24,6 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    rb-fchange (0.0.6)
-      ffi
-    rb-fsevent (0.9.3)
-    rb-inotify (0.9.0)
-      ffi (>= 0.5.0)
     rb-notifu (0.0.4)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
@@ -48,8 +43,5 @@ DEPENDENCIES
   growl
   guard-rspec
   libnotify
-  rb-fchange
-  rb-fsevent
-  rb-inotify
   rb-notifu
   rspec (= 2.13.0)


### PR DESCRIPTION
`Gemfile` 内のコメントの https://github.com/guard/guard#efficient-filesystem-handling がリンク切れになっていたので調べたところ、guard本家で「Removed outdated section about filesystem handling」とあったのでスケルトンの方でも消しました。（なくてもちゃんとgrowlで通知来たので問題ないかと）

ref. https://github.com/guard/guard/commit/df14312317c29d5cc5d4f990b515f2aeabca89bb
