### PR TITLE
Rubyとbundlerのバージョンを更新

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.6.6
+  - 2.7.1
   - ruby-head
 script:
   - bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,4 +72,4 @@ DEPENDENCIES
   rspec-power_assert
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TDDBC for Ruby with RSpec
 [![Build Status](https://travis-ci.org/tddbc/ruby_rspec.svg?branch=master)](https://travis-ci.org/tddbc/ruby_rspec)
 
 ## 動作確認環境
-* ruby 2.1以降
+* ruby 2.7以降
 
 ## セットアップ
 ```bash
@@ -25,9 +25,17 @@ Sample
       should say 'Hello TDD BootCamp!'
     Using subject it should
       should eq "Yeah! TDD BootCamp!"
+    Using power assert
+      should 
+            be asserted by{ sample.say(greeting) == "Wow! TDD BootCamp!" }
+                            |      |   |         |
+                            |      |   |         true
+                            |      |   "Wow!"
+                            |      "Wow! TDD BootCamp!"
+                            #<Sample:0x0000563cf08833e8>
 
-Finished in 0.00218 seconds (files took 0.1389 seconds to load)
-2 examples, 0 failures
+Finished in 0.10792 seconds (files took 0.80775 seconds to load)
+3 examples, 0 failures
 ```
 
 のようにテストが正常終了すればOKです。


### PR DESCRIPTION
現在の最新stableバージョンである2.7で動作確認を行ったのでREADMEを修正しました。
また、放置されてしまっている #16 と同様にrspec実行時のpower-assertのログをサンプルとしてREADMEに記載するようにしました。

Gemfile.lockのbundlerが1系のままになっており、そのままではruby 2.7では `bundle install` もできなかったので`bundle update --bundler`で2系に更新しておきました。